### PR TITLE
recommended changes from testing on Red Hat 8

### DIFF
--- a/Makefile_linux_template
+++ b/Makefile_linux_template
@@ -8,9 +8,9 @@ STATIC =
 ##INCL## INCL = Makefile_linux PROGRAMNAME.incl
 ##STATIC## STATIC = -static
 
-fc =	 gfortran -DLINUX -m32
+fc =	 gfortran -DLINUX -m32 -std=legacy
 
-opt= -O -u -check_bounds -ffixed-line-length-132 -I..
+opt= -O -u -ffixed-line-length-132 -I..
 link= -O
 
 $(EXEC):	$(OBJ) $(SUBS)

--- a/gklib/make_fresh_gklib.csh
+++ b/gklib/make_fresh_gklib.csh
@@ -74,11 +74,11 @@ echo "Building LINUX gklib library"
 
 set lib=linux_kleylib
 
-set fort='gfortran -DLINUX -O -u -g -check_bounds -fbacktrace -fbounds-check -m32 -std=legacy -ffixed-line-length-132'
+set fort="gfortran -DLINUX -O -u -g -m"$int_size" -std=legacy -ffixed-line-length-132"
 
 
 #set ccom='cc -c -g -DOSX'
-set ccom='gcc -c -g -DLINUX -m32 '
+set ccom="gcc -c -g -DLINUX -m"$int_size
 
 # backup existing library
 if (-e $lib) mv $lib {$lib}.ckp

--- a/make_all.csh
+++ b/make_all.csh
@@ -139,7 +139,7 @@ set echo
 
 cd $LIB_DIR
 
-if ("$skiplib" == "") make_fresh_gklib.csh $OS $int_size
+if ("$skiplib" == "") ./make_fresh_gklib.csh $OS $int_size
 
 if ($status < 0) then
     echo "Error - gklib build failed"

--- a/mapman_compile_instructions.csh
+++ b/mapman_compile_instructions.csh
@@ -1,0 +1,45 @@
+#! /bin/tcsh -f
+#
+#   get mapman working using git repositories
+#
+
+# needed after default RedHat 8.4 install (run as root)
+if ( `whoami` == "root" ) then
+yum install tcsh 
+yum install make git m4 patch
+yum install gcc gcc-gfortran libgfortran
+# hopefully your sysadmin already did this
+endif
+
+# regular user start here
+
+# re-compile ccp4 libraries
+git clone https://github.com/dials/ccp4io
+cd ccp4io/libccp4/
+chmod a+x configure 
+./configure
+make
+cd ../..
+
+
+# now get the version of USF being maintained by Martyn Winn
+git clone https://github.com/martynwinn/Uppsala-Software-Factory
+cd Uppsala-Software-Factory
+
+# a few corrections...
+mkdir bin
+mkdir ccp4libs_latest_m64_linux
+
+# copy in CCP4 libs
+cp ../ccp4io/libccp4/fortran/.libs/libccp4f.a ccp4libs_latest_m64_linux/
+cp ../ccp4io/libccp4/ccp4/.libs/libccp4c.a ccp4libs_latest_m64_linux/
+
+# do the build
+./make_all.csh mapman -64
+
+# test it
+wget https://raw.githubusercontent.com/fraser-lab/holton_scripts/master/map_bender/mapman_regression_test.csh
+chmod a+x mapman_regression_test.csh
+./mapman_regression_test.csh ./bin/mapman
+
+


### PR DESCRIPTION
Greetings Martyn, and thank you for maintaining this repository of the USF!

I recently had a user having trouble with a seg fault on redhat 8, which no longer supports static libs!  Using static libs compiled in CentOS caused the crash.  Devised instructions on how to re-compile from scratch and contributed these as mapman_compile_instructions.csh
a few edits needed to make_all.csh and make_fresh_gklib.csh as well to make it work on Red Hat Linux. Also still works on CentOS.